### PR TITLE
Addresses cases where body may be inexistent

### DIFF
--- a/Sources/SwiftlyRest/Protocols/SwiftlyRestInterface.swift
+++ b/Sources/SwiftlyRest/Protocols/SwiftlyRestInterface.swift
@@ -77,7 +77,7 @@ protocol SwiftlyRestInterface {
     @available(iOS 15.0, *)
     func post<T: Codable, U: Codable>(
         _ endpoint: EndpointInterface,
-        body: U,
+        body: U?,
         headers: [String: String]
     ) async -> Result<T, SwiftlyRestError>
     
@@ -93,7 +93,7 @@ protocol SwiftlyRestInterface {
     @available(iOS 15.0, *)
     func patch<T: Codable, U: Codable>(
         _ endpoint: EndpointInterface,
-        body: U,
+        body: U?,
         headers: [String: String]
     ) async -> Result<T, SwiftlyRestError>
     
@@ -109,7 +109,7 @@ protocol SwiftlyRestInterface {
     @available(iOS 15.0, *)
     func put<T: Codable, U: Codable>(
         _ endpoint: EndpointInterface,
-        body: U,
+        body: U?,
         headers: [String: String]
     ) async -> Result<T, SwiftlyRestError>
     

--- a/Sources/SwiftlyRest/SwiftlyRest.swift
+++ b/Sources/SwiftlyRest/SwiftlyRest.swift
@@ -175,7 +175,7 @@ public class SwiftlyRest: SwiftlyRestInterface {
     @available(iOS 15.0, *)
     public func post<T: Codable, U: Codable>(
         _ endpoint: EndpointInterface,
-        body: U,
+        body: U? = nil,
         headers: [String: String] = [:]
     ) async -> Result<T, SwiftlyRestError> {
         return await makeRequest(endpoint: endpoint, method: .post, body: body, responseType: T.self, headers: headers)
@@ -193,7 +193,7 @@ public class SwiftlyRest: SwiftlyRestInterface {
     @available(iOS 15.0, *)
     public func patch<T: Codable, U: Codable>(
         _ endpoint: EndpointInterface,
-        body: U,
+        body: U? = nil,
         headers: [String: String] = [:]
     ) async -> Result<T, SwiftlyRestError> {
         return await makeRequest(endpoint: endpoint, method: .patch, body: body, responseType: T.self, headers: headers)
@@ -211,7 +211,7 @@ public class SwiftlyRest: SwiftlyRestInterface {
     @available(iOS 15.0, *)
     public func put<T: Codable, U: Codable>(
         _ endpoint: EndpointInterface,
-        body: U,
+        body: U? = nil,
         headers: [String: String] = [:]
     ) async -> Result<T, SwiftlyRestError> {
         return await makeRequest(endpoint: endpoint, method: .put, body: body, responseType: T.self, headers: headers)


### PR DESCRIPTION
When performing PATCH, POST and PUT requests, the body is currently required, even if we don't need it.

This pull request addresses this issue by modifying the `body` type from `U` to `U?` (default = `nil`).
- This is compliant with the existing `makeRequest()` method.